### PR TITLE
feat: strip webchat envelope metadata from user messages

### DIFF
--- a/src/components/ChatMessage.tsx
+++ b/src/components/ChatMessage.tsx
@@ -14,7 +14,7 @@ import { copyToClipboard } from '../lib/clipboard';
 import { Bot, User, Wrench, Copy, Check, CheckCheck, RefreshCw, Zap, Info, Webhook, Braces, Clock, AlertCircle, Bookmark, ChevronDown, Reply } from 'lucide-react';
 import { t, getLocale } from '../lib/i18n';
 import { useLocale } from '../hooks/useLocale';
-import { stripWebhookScaffolding, hasWebhookScaffolding } from '../lib/systemEvent';
+import { stripWebhookScaffolding, hasWebhookScaffolding, hasWebchatEnvelope, stripWebchatEnvelope } from '../lib/systemEvent';
 // ChevronDown, ChevronRight, Wrench still used by InternalOnlyMessage
 
 /** Avatar image with fallback to Bot icon on load error */
@@ -443,26 +443,38 @@ export const ChatMessageComponent = memo(function ChatMessageComponent({ message
   const isLight = resolvedTheme === 'light';
   const [showRawJson, setShowRawJson] = useState(false);
 
-  // Strip webhook/hook scaffolding from user messages before rendering
+  // Strip webhook/hook scaffolding and webchat envelope from user messages before rendering
   const message = useMemo(() => {
     if (rawMessage.role !== 'user') return rawMessage;
     const content = rawMessage.content || '';
     const textBlocks = getTextBlocks(rawMessage.blocks);
-    const contentHasScaffolding = hasWebhookScaffolding(content);
-    const anyBlockHasScaffolding = textBlocks.some(b =>
-      hasWebhookScaffolding((b as Extract<MessageBlock, { type: 'text' }>).text)
-    );
-    if (!contentHasScaffolding && !anyBlockHasScaffolding) return rawMessage;
+
+    // Helper: apply all applicable strip functions to a string
+    const stripAll = (text: string): string => {
+      let result = text;
+      if (hasWebhookScaffolding(result)) result = stripWebhookScaffolding(result);
+      if (hasWebchatEnvelope(result)) result = stripWebchatEnvelope(result);
+      return result;
+    };
+
+    const contentNeedsStrip = hasWebhookScaffolding(content) || hasWebchatEnvelope(content);
+    const anyBlockNeedsStrip = textBlocks.some(b => {
+      const t = (b as Extract<MessageBlock, { type: 'text' }>).text;
+      return hasWebhookScaffolding(t) || hasWebchatEnvelope(t);
+    });
+
+    if (!contentNeedsStrip && !anyBlockNeedsStrip) return rawMessage;
+
     // Clean the content and blocks
     const cleaned: ChatMessageType = { ...rawMessage };
     if (cleaned.content) {
-      cleaned.content = stripWebhookScaffolding(cleaned.content);
+      cleaned.content = stripAll(cleaned.content);
     }
     if (cleaned.blocks.length > 0) {
       cleaned.blocks = cleaned.blocks.map(b => {
         if (b.type === 'text') {
           const tb = b as Extract<MessageBlock, { type: 'text' }>;
-          return { ...tb, text: stripWebhookScaffolding(tb.text) };
+          return { ...tb, text: stripAll(tb.text) };
         }
         return b;
       });
@@ -470,7 +482,7 @@ export const ChatMessageComponent = memo(function ChatMessageComponent({ message
     return cleaned;
   }, [rawMessage]);
 
-  const wasWebhookMessage = rawMessage !== message;
+  const wasWebhookMessage = rawMessage !== message && hasWebhookScaffolding(rawMessage.content || '');
 
   const isUser = message.role === 'user';
 

--- a/src/lib/systemEvent.ts
+++ b/src/lib/systemEvent.ts
@@ -81,3 +81,45 @@ export function hasWebhookScaffolding(text: string): boolean {
   return /<<<EXTERNAL_UNTRUSTED_CONTENT>>>/.test(text) ||
     /---\s*SECURITY NOTICE\s*---/i.test(text);
 }
+
+/**
+ * Detect OpenClaw webchat envelope metadata in a user message.
+ *
+ * Pattern:
+ *   Conversation info (untrusted metadata):
+ *   ```json
+ *   { ... }
+ *   ```
+ *
+ *   [Wed 2026-02-18 14:06 UTC] actual message
+ */
+export function hasWebchatEnvelope(text: string): boolean {
+  return /Conversation info \(untrusted metadata\):/.test(text) ||
+    /^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\] /.test(text.trim());
+}
+
+/**
+ * Strip webchat envelope metadata from a user message, returning only the
+ * actual user text.
+ *
+ * Removes:
+ *  - "Conversation info (untrusted metadata):" header + trailing JSON code fence
+ *  - Timestamp prefix "[Wed 2026-02-18 14:06 UTC] "
+ */
+export function stripWebchatEnvelope(text: string): string {
+  let cleaned = text;
+
+  // Remove the "Conversation info (untrusted metadata):" block + JSON code fence
+  cleaned = cleaned.replace(
+    /Conversation info \(untrusted metadata\):\s*```json\s*[\s\S]*?```\s*/,
+    ''
+  );
+
+  // Strip timestamp prefix: [Wed 2026-02-18 14:06 UTC]
+  cleaned = cleaned.replace(
+    /^\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun) \d{4}-\d{2}-\d{2} \d{2}:\d{2} UTC\] /,
+    ''
+  );
+
+  return cleaned.trim() || text.trim();
+}


### PR DESCRIPTION
When OpenClaw's webchat relays user messages, it wraps them in metadata (conversation info JSON + UTC timestamp). This strips the envelope so users see only their actual text.

**Before:** Message shows `Conversation info (untrusted metadata): {"message_id": "...", "sender": "webchat"} [Wed 2026-02-18 14:06 UTC] Nice - thanks`

**After:** Message shows `Nice - thanks`

## Description

Adds webchat envelope detection and stripping alongside the existing webhook scaffolding system. When history is reloaded from the gateway, user messages come back wrapped in OpenClaw's internal metadata envelope. This strips it at render time.

Also fixes the "webhook" label incorrectly appearing on envelope-stripped messages — now only shows for actual webhook messages.

### Changes
- `src/lib/systemEvent.ts` — New `hasWebchatEnvelope()` and `stripWebchatEnvelope()` functions with JSDoc
- `src/components/ChatMessage.tsx` — `stripAll()` helper chains both strip passes; `wasWebhookMessage` now checks for actual webhook scaffolding before labeling

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Documentation
- [x] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests
- [ ] 🔧 CI / tooling

## Checklist

- [x] `npm run lint` passes with 0 errors
- [x] `npm run build` succeeds
- [x] `npm test` passes (137 passing)
- [ ] Tested in Dark, Light, and OLED themes
- [x] Mobile-responsive (375px+)
- [ ] i18n keys added for new user-facing strings (EN + FR)
- [x] No secrets or `.env` values committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Screenshots (if UI change)

**Before:** User message rendered with full metadata envelope + JSON code block + timestamp prefix
**After:** Clean user message text only, no "webhook" mislabel
