### PR TITLE
Fix/chinese ime enter send

### DIFF
--- a/src/components/ChatInput.tsx
+++ b/src/components/ChatInput.tsx
@@ -98,6 +98,7 @@ export function ChatInput({ onSend, onNewSession, onAbort, isGenerating, disable
   const [files, setFiles] = useState<FileAttachment[]>([]);
   const [isDragOver, setIsDragOver] = useState(false);
   const [showPreview, setShowPreview] = useState(() => localStorage.getItem('pinchchat-md-preview') === '1');
+  const [isComposing, setIsComposing] = useState(false);
   const [showSlash, setShowSlash] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
@@ -208,7 +209,7 @@ export function ChatInput({ onSend, onNewSession, onAbort, isGenerating, disable
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter') {
       // Prevent sending when IME is composing (e.g., Chinese/Japanese input)
-      if (e.isComposing) return;
+      if (isComposing) return;
       if (sendOnEnter) {
         // Enter sends, Shift+Enter for newline
         if (!e.shiftKey && !e.ctrlKey && !e.metaKey) {
@@ -385,6 +386,8 @@ export function ChatInput({ onSend, onNewSession, onAbort, isGenerating, disable
               value={text}
               onChange={(e) => { setText(e.target.value); setShowSlash(shouldShowSlashMenu(e.target.value)); }}
               onKeyDown={handleKeyDown}
+              onCompositionStart={() => setIsComposing(true)}
+              onCompositionEnd={() => setIsComposing(false)}
               onPaste={handlePaste}
               placeholder={t('chat.inputPlaceholder')}
               aria-label={t('chat.inputLabel')}


### PR DESCRIPTION
## Description

This PR fixes an issue where pressing Enter to confirm Chinese/Japanese IME input would prematurely send the message instead of just confirming the character selection.

## Type of change

- [x] 🐛 Bug fix

## What changed

- Added `isComposing` state to track IME composition status
- Added `onCompositionStart` and `onCompositionEnd` event handlers to the textarea
- Check `isComposing` state in the Enter key handler to prevent accidental sends

## Why this approach

Using explicit composition state tracking (`onCompositionStart`/`onCompositionEnd`) instead of relying solely on `e.isComposing` provides more reliable cross-browser behavior for Chinese, Japanese, and other IME input methods.

## Testing

Tested with Chinese Pinyin IME:
- Typing "nihao" and pressing Enter to select "你好" no longer sends the message prematurely
- After IME selection completes, pressing Enter sends the message as expected
- Shift+Enter still works for newlines
- Ctrl+Enter / Cmd+Enter still works when "Ctrl+Enter to send" mode is enabled

## Checklist

- [x] No behavior changes for non-IME users
- [x] No secrets or `.env` values committed
- [x] Commit messages follow Conventional Commits