### PR TITLE
fix: slash command menu stays open after autocomplete Enter

### DIFF
--- a/src/lib/slashUtils.ts
+++ b/src/lib/slashUtils.ts
@@ -1,5 +1,5 @@
 /** Check if slash command menu should be shown */
 export function shouldShowSlashMenu(text: string): boolean {
   const trimmed = text.trimStart();
-  return trimmed.startsWith('/') && !trimmed.includes('\n');
+  return trimmed.startsWith('/') && !trimmed.includes('\n') && !trimmed.includes(' ');
 }


### PR DESCRIPTION
## Description

Prevent the slash menu from reappearing when the user presses Enter to send a message after selecting a command via autocomplete. The menu now hides as soon as the command name is complete (a space is typed).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactor (no behavior change)
- [ ] 📝 Documentation
- [ ] 🎨 Style / UI
- [ ] ⚡ Performance
- [ ] 🧪 Tests
- [ ] 🔧 CI / tooling

## Checklist

- [x] `npm run lint` passes with 0 errors
- [x] `npm run build` succeeds
- [x] `npm test` passes
- [ ] Tested in Dark, Light, and OLED themes
- [ ] Mobile-responsive (375px+)
- [ ] i18n keys added for new user-facing strings (EN + FR)
- [ ] No secrets or `.env` values committed
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
