### PR TITLE
fix: don't blacklist session on failed delete

### DIFF
--- a/src/hooks/useGateway.ts
+++ b/src/hooks/useGateway.ts
@@ -472,9 +472,11 @@ export function useGateway() {
     try {
       await clientRef.current?.send('sessions.delete', { key, deleteTranscript: true });
     } catch {
-      // Ignore delete failures — blacklist will hide it anyway
+      // If the gateway rejects the delete, don't blacklist — the session still exists
+      // and hiding it would make it permanently invisible until localStorage is cleared.
+      return;
     }
-    // Persist to blacklist so it stays hidden after refresh
+    // Only blacklist and hide if the delete actually succeeded
     addDeletedSession(key);
     // Remove from local state
     setSessions(prev => prev.filter(s => s.key !== key));


### PR DESCRIPTION
## Summary

- When `sessions.delete` is rejected by the gateway (e.g. "webchat clients cannot delete sessions"), the session was still added to the local `localStorage` blacklist, making it permanently invisible in the sidebar
- Users had to manually run `localStorage.removeItem('pinchchat-deleted-sessions')` in the browser console to recover hidden sessions
- Now we return early on delete failure so the session remains visible

## Test plan

- [ ] Connect PinchChat to a gateway that rejects `sessions.delete` for webchat clients
- [ ] Try to delete a session from the sidebar
- [ ] Verify the session remains visible after the delete fails
- [ ] Verify sessions that are successfully deleted still get hidden as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)