### PR TITLE
Support OpenClaw protocol 4 (widen advertised protocol range to 3–4)

### DIFF
--- a/src/lib/gateway.ts
+++ b/src/lib/gateway.ts
@@ -153,7 +153,7 @@ export class GatewayClient {
     try {
       const res = await this.request(id, 'connect', {
         minProtocol: 3,
-        maxProtocol: 3,
+        maxProtocol: 4,
         client: { id: this.clientId, version: __APP_VERSION__, platform: 'web', mode: 'webchat' },
         role,
         scopes,


### PR DESCRIPTION
Fixes #42 

## What

Widens the protocol version range advertised in the connect handshake from `minProtocol: 3 / maxProtocol: 3` to `minProtocol: 3 / maxProtocol: 4` in `src/lib/gateway.ts`.

## Why

Current OpenClaw gateways (2026.6.1) run on wire protocol 4. Per OpenClaw's protocol model, a client sends `minProtocol`/`maxProtocol` and the gateway rejects the connection if its current protocol isn't inside that range. PinchChat advertised `3/3`, so against a protocol-4 gateway the connect frame is rejected during negotiation with `PROTOCOL_MISMATCH` (close code `1002`) — before auth or pairing. Full diagnosis is in the linked issue.

Advertising `3–4` rather than pinning to `4` keeps PinchChat compatible with both older protocol-3 gateways and current protocol-4 gateways; the gateway negotiates down to whichever protocol it currently runs.

## Testing

- Built from source against an OpenClaw `2026.6.1` gateway (protocol 4) over a `wss://` reverse proxy.
- With the range including 4, the handshake completed end to end: protocol negotiation, the `connect.challenge` response, and connect-param validation all passed, with no further protocol or schema errors. (The only remaining gate was the standard `gateway.controlUi.allowedOrigins` origin check, which is expected gateway configuration and unrelated to this change.)
- I only had a protocol-4 gateway available, so the protocol-3 negotiation path is not directly exercised here; `minProtocol: 3` is retained as the backward-compatible, negotiation-correct lower bound per the OpenClaw protocol docs rather than because I tested a v3 gateway.

## Notes

- This is a single-line change to the advertised `maxProtocol` value.
- A separate, optional improvement (not included here to keep the diff focused): surface the real close reason in the UI instead of "check URL and token" for non-auth failures like `PROTOCOL_MISMATCH`. Happy to open that as a follow-up PR if useful.